### PR TITLE
Upgrade to B1 to include custom domain names

### DIFF
--- a/Infra/webapp.bicep
+++ b/Infra/webapp.bicep
@@ -19,7 +19,7 @@ resource appPlan 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: appServicePlanName
   location: location
   sku: {
-    name: 'F1'
+    name: 'B1'
   }
   kind: 'linux'
   properties: {


### PR DESCRIPTION
B1 supports custom domain names, F1 (the free tier) does not.